### PR TITLE
Adding NPC to Server Status

### DIFF
--- a/status.cpp
+++ b/status.cpp
@@ -202,6 +202,10 @@ std::string Status::getStatusString() const
 	addXMLProperty(p, "total", g_game.getMonstersOnline());
 	xmlAddChild(root, p);
 
+	p = xmlNewNode(NULL,(const xmlChar*)"npcs");
+	addXMLProperty(p, "total", g_game.getNpcsOnline());
+	xmlAddChild(root, p);
+
 	uint32_t mapWidth, mapHeight;
 	g_game.getMapDimensions(mapWidth, mapHeight);
 


### PR DESCRIPTION
This will send the total of loaded NPCS to OTServ Lists and other tools that capture such Server Information.