### PR TITLE
Party Self-Invite Crash Fix

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -5377,8 +5377,8 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return false;
 	}
 
-	if(playerId == inviteId)
-		return;
+	if(playerId == invitedId)
+		return false;
 
 	Party* party = player->getParty();
 	if(!party)

--- a/game.cpp
+++ b/game.cpp
@@ -5377,6 +5377,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return false;
 	}
 
+	if(playerId == inviteId)
+		return;
+
 	Party* party = player->getParty();
 	if(!party)
 		party = new Party(player);


### PR DESCRIPTION
This will not allow the player to invite himself to the party (possible with otclient terminal).